### PR TITLE
This pull request solves an event fetching bug

### DIFF
--- a/Conhics/Input/Keyboard.cs
+++ b/Conhics/Input/Keyboard.cs
@@ -35,7 +35,7 @@ namespace Conhics.Input {
                 if (inputQueue.TryDequeue(out var firstInput))
                     return firstInput;
 
-                return LastInput;
+                return null;
             }
         }
 


### PR DESCRIPTION
As mentioned in #4 there was a problem that ment that once an event has started the Keyboard.Input would never become null again, thus resulting in an infinit amout of events